### PR TITLE
Update instructions to reference the correct command

### DIFF
--- a/docs/exercise_1.rst
+++ b/docs/exercise_1.rst
@@ -184,7 +184,7 @@ the ShopFrontend to AWS ElasticBeanstalk.
                 --version-label v1
 
         You now need to wait for the environment to become Ready again. You
-        can use the snippet above to do that. Keep repeating this command
+        can use the snippet below to do that. Keep repeating this command
         until you get `Ready` as a response.
 
         .. code-block:: bash


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The instructions mention a command for the user to run to check the status of the elasticbeanstalk environment but they point the user to the command used to update the environment rather than the one to describe the status. This PR updates the docs to point the user to the correct command below the instructions rather than above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
